### PR TITLE
Fix Null Check on TCP/UDP Listeners

### DIFF
--- a/ARSoft.Tools.Net/Dns/DnsServer.cs
+++ b/ARSoft.Tools.Net/Dns/DnsServer.cs
@@ -132,11 +132,11 @@ namespace ARSoft.Tools.Net.Dns
 		/// </summary>
 		public void Stop()
 		{
-			if (_udpListenerCount > 0)
+			if (_udpListener != null && _udpListenerCount > 0)
 			{
 				_udpListener.Close();
 			}
-			if (_tcpListenerCount > 0)
+			if (_tcpListener != null && _tcpListenerCount > 0)
 			{
 				_tcpListener.Stop();
 			}
@@ -369,7 +369,7 @@ namespace ARSoft.Tools.Net.Dns
 		{
 			lock (_listenerLock)
 			{
-				if (!_tcpListener.Server.IsBound) // server is stopped
+				if ((_tcpListener.Server == null) || !_tcpListener.Server.IsBound) // server is stopped
 					return;
 
 				if ((_availableTcpListener > 0) && !_hasActiveTcpListener)


### PR DESCRIPTION
The problem:
System.NullReferenceException: Object reference not set to an instance of an object.
   at ARSoft.Tools.Net.Dns.DnsServer.StartTcpListenerTask() in ARSoft.Tools.Net\Dns\DnsServer.cs:line 372
   at ARSoft.Tools.Net.Dns.DnsServer.<HandleTcpListenerAsync>d__26.MoveNext() in ARSoft.Tools.Net\Dns\DnsServer.cs:line 536

Solution:
The Upd listener had the null check on client, but the tcp listener did not.
